### PR TITLE
Wifi Connect

### DIFF
--- a/src/content/apps/pedroomar23/Wifi-Connect.md
+++ b/src/content/apps/pedroomar23/Wifi-Connect.md
@@ -4,7 +4,7 @@ id: "Wifi-Connect"
 description: "Wifi Connect es una app que ayuda a la comunidad iOS en Cuba a acceder a la Wifi Pública, Nauta Hogar y Nauta Plus. La app esta disponible en la App Store"
 logo: "icon-wifi-connet-ligth.jpg"
 email: "pocl9812@gmail.com"
-website: "[https://www.innovapp-soft.com](https://apps.apple.com/us/app/wifi-connect/id6496852984)"
+website: "[https://apps.apple.com/us/app/wifi-connect/id6496852984](https://apps.apple.com/us/app/wifi-connect/id6496852984)"
 is_open_source: false
 repository_url: ""
 twitter_username: "pedroomar25"

--- a/src/content/apps/pedroomar23/Wifi-Connect.md
+++ b/src/content/apps/pedroomar23/Wifi-Connect.md
@@ -4,7 +4,7 @@ id: "Wifi-Connect"
 description: "Wifi Connect es una app que ayuda a la comunidad iOS en Cuba a acceder a la Wifi Pública, Nauta Hogar y Nauta Plus. La app esta disponible en la App Store"
 logo: "icon-wifi-connet-ligth.jpg"
 email: "pocl9812@gmail.com"
-website: "https://www.innovapp-soft.com"
+website: "[https://www.innovapp-soft.com](https://apps.apple.com/us/app/wifi-connect/id6496852984)"
 is_open_source: false
 repository_url: ""
 twitter_username: "pedroomar25"

--- a/src/content/apps/pedroomar23/Wifi-Connect.md
+++ b/src/content/apps/pedroomar23/Wifi-Connect.md
@@ -1,0 +1,18 @@
+---
+name: "Wifi Connect"
+id: "Wifi-Connect"
+description: "Wifi Connect es una app que ayuda a la comunidad iOS en Cuba a acceder a la Wifi Pública, Nauta Hogar y Nauta Plus. La app esta disponible en la App Store"
+logo: "icon-wifi-connet-ligth.jpg"
+email: "pocl9812@gmail.com"
+website: "https://www.innovapp-soft.com"
+is_open_source: false
+repository_url: ""
+twitter_username: "pedroomar25"
+telegram_username: "pedroomar23"
+dev_username: "pedroomar23"
+pubDate: "Thu Dec 26 2024"
+categories: ["productivity","communication"]
+platforms: ["iOS","macOS"]
+---
+
+Wifi Connect es una app que ayuda a la comunidad iOS en Cuba a acceder a la Wifi Pública, Nauta Hogar y Nauta Plus. La app esta disponible en la App Store


### PR DESCRIPTION
Wifi Connect es una app que ayuda a los usuarios a acceder a la Wifi Pública, Nauta Hogar y Nauta Plus de una forma más fácil.